### PR TITLE
this function is lowercase in latest version

### DIFF
--- a/src/JSN-SR04_Gen3_RK.cpp
+++ b/src/JSN-SR04_Gen3_RK.cpp
@@ -178,7 +178,7 @@ void JSN_SR04_Gen3::startState() {
 	attachInterruptDirect(I2S_IRQn, nrfx_i2s_irq_handler, false);
 
 
-    Hal_Pin_Info *pinMap = HAL_Pin_Map();
+    Hal_Pin_Info *pinMap = Hal_Pin_Map();
 
     nrfx_i2s_config_t config = NRFX_I2S_DEFAULT_CONFIG;
 


### PR DESCRIPTION
Fixes error when compiling this library
```
JSN-SR04_Gen3_RK.cpp:181:28: 'HAL_Pin_Map' was not declared in this scope; did you mean 'Hal_Pin_Map'?
```